### PR TITLE
Add July 2025 postage rates

### DIFF
--- a/src/algorithm/prices_20250713.json
+++ b/src/algorithm/prices_20250713.json
@@ -1,0 +1,17 @@
+{
+    "postcard": {
+        "base": 61,
+        "additional": 0,
+        "international": 170
+    },
+    "letter": {
+        "base": 78,
+        "additional": 29,
+        "international": 170
+    },
+    "large_envelope": {
+        "base": 163,
+        "additional": 27,
+        "international": 315
+    }
+}

--- a/src/algorithm/stamp.ts
+++ b/src/algorithm/stamp.ts
@@ -1,5 +1,10 @@
 // https://pe.usps.com/text/dmm300/Notice123.htm
-import priceTable from './prices_20240714.json';
+import prices2024 from './prices_20240714.json';
+import prices2025 from './prices_20250713.json';
+
+const EFFECTIVE_2025 = new Date('2025-07-13');
+const today = new Date();
+const priceTable = today >= EFFECTIVE_2025 ? prices2025 : prices2024;
 
 export function displayPrice(value: number): string {
     if (value < 100) {


### PR DESCRIPTION
## Summary
- add postage prices effective July 13, 2025
- update algorithm to use 2025 rates only after July 13, 2025

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68657895d98c833181881f84265d43b3