### PR TITLE
Add editable stamps list with cookie persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ const App: React.FC = () => {
         if (cookieData.selected.includes(stamp.id)) {
           sel.set(stamp.id, stamp);
         }
-      } else if (stamp.value !== 65) {
+      } else {
         sel.set(stamp.id, stamp);
       }
     });
@@ -65,7 +65,7 @@ const App: React.FC = () => {
     setSelected((prev) => {
       const newMap = new Map<string, Stamp>();
       stamps.forEach((s) => {
-        if (prev.has(s.id) || (!cookieData && s.value !== 65)) {
+        if (prev.has(s.id) || !cookieData) {
           newMap.set(s.id, s);
         }
       });
@@ -92,15 +92,11 @@ const App: React.FC = () => {
       ))
     : <div>No solution</div>;
 
-  const stampButtonsKey =
-    stamps.map((s) => s.id).join(',') + Array.from(selected.keys()).join(',');
-
   return (
     <div className="App">
       <EditStamps stampValues={stampValues} onUpdate={setStampValues} />
       <div>
         <StampButtons
-          key={stampButtonsKey}
           stamps={stamps}
           onSelectionChanged={setSelected}
           initialSelection={selected}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,85 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import StampButtons from './components/StampButtons';
 import Postage from './components/Postage';
+import EditStamps from './components/EditStamps';
 import { calculate, Solution } from './algorithm/calculate';
 import { Stamp } from './algorithm/stamp';
+import { getCookie, setCookie } from './cookie';
 
 import './App.css';
 
 const App: React.FC = () => {
-  const stamps = ([1, 3, 5, 10, 29, 32, 33, 65, 86]
-    .map((v) => Stamp.fixed(v))
-    .concat([Stamp.forever(), Stamp.globalForever()]))
-    .sort((a, b) => a.value - b.value);
-  
-  // Initialize selected state with all stamps except 65¢
-  const initialSelected = new Map<string, Stamp>();
-  stamps.forEach(stamp => {
-    if (stamp.value !== 65) {
-      initialSelected.set(stamp.id, stamp);
+  const DEFAULT_VALUES = [1, 3, 5, 10, 29, 32, 33, 65, 86];
+
+  type CookieState = {
+    values: number[];
+    selected: string[];
+  };
+
+  const cookieData: CookieState | null = (() => {
+    const c = getCookie('stamp-state');
+    if (!c) return null;
+    try {
+      return JSON.parse(c);
+    } catch {
+      return null;
     }
-  });
-  
-  const [selected, setSelected] = useState<Map<string, Stamp>>(initialSelected);
+  })();
+
+  const [stampValues, setStampValues] = useState<number[]>(
+    cookieData?.values || DEFAULT_VALUES,
+  );
+
+  const makeStamps = (values: number[]) =>
+    values
+      .map((v) => Stamp.fixed(v))
+      .concat([Stamp.forever(), Stamp.globalForever()])
+      .sort((a, b) => a.value - b.value);
+
+  const [stamps, setStamps] = useState<Stamp[]>(makeStamps(stampValues));
+
+  const makeInitialSelected = (stampList: Stamp[]) => {
+    const sel = new Map<string, Stamp>();
+    stampList.forEach((stamp) => {
+      if (cookieData?.selected) {
+        if (cookieData.selected.includes(stamp.id)) {
+          sel.set(stamp.id, stamp);
+        }
+      } else if (stamp.value !== 65) {
+        sel.set(stamp.id, stamp);
+      }
+    });
+    return sel;
+  };
+
+  const [selected, setSelected] = useState<Map<string, Stamp>>(
+    makeInitialSelected(stamps),
+  );
   const [solution, setSolution] = useState<Solution | null>(null);
+
+  useEffect(() => {
+    setStamps(makeStamps(stampValues));
+  }, [stampValues]);
+
+  useEffect(() => {
+    setSelected((prev) => {
+      const newMap = new Map<string, Stamp>();
+      stamps.forEach((s) => {
+        if (prev.has(s.id) || (!cookieData && s.value !== 65)) {
+          newMap.set(s.id, s);
+        }
+      });
+      return newMap;
+    });
+  }, [stamps]);
+
+  useEffect(() => {
+    const data: CookieState = {
+      values: stampValues,
+      selected: Array.from(selected.keys()),
+    };
+    setCookie('stamp-state', JSON.stringify(data));
+  }, [stampValues, selected]);
 
   const getSolutions = (postage: number): void => {
     const result = calculate(Array.from(selected.values()), postage);
@@ -34,10 +92,19 @@ const App: React.FC = () => {
       ))
     : <div>No solution</div>;
 
+  const stampButtonsKey =
+    stamps.map((s) => s.id).join(',') + Array.from(selected.keys()).join(',');
+
   return (
     <div className="App">
+      <EditStamps stampValues={stampValues} onUpdate={setStampValues} />
       <div>
-        <StampButtons stamps={stamps} onSelectionChanged={setSelected} initialSelection={initialSelected} />
+        <StampButtons
+          key={stampButtonsKey}
+          stamps={stamps}
+          onSelectionChanged={setSelected}
+          initialSelection={selected}
+        />
       </div>
       <div>
         <Postage onSetPostage={(p: number) => getSolutions(p)} />

--- a/src/components/EditStamps.tsx
+++ b/src/components/EditStamps.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { Box, Button, Input } from '@chakra-ui/react';
+
+interface EditStampsProps {
+  stampValues: number[];
+  onUpdate: (values: number[]) => void;
+}
+
+const EditStamps: React.FC<EditStampsProps> = ({ stampValues, onUpdate }) => {
+  const [valueText, setValueText] = useState(stampValues.join(', '));
+
+  const parseValues = (text: string): number[] => {
+    return Array.from(new Set(text.split(/[,\s]+/)
+      .map(v => parseInt(v))
+      .filter(v => !isNaN(v) && v > 0)))
+      .sort((a, b) => a - b);
+  };
+
+  return (
+    <Box marginTop={'1rem'} marginBottom={'1rem'}>
+      <Input
+        value={valueText}
+        onChange={e => setValueText(e.currentTarget.value)}
+        placeholder="Enter stamp values separated by commas"
+        width="20rem"
+        marginRight="0.5rem"
+      />
+      <Button onClick={() => onUpdate(parseValues(valueText))}>Save</Button>
+    </Box>
+  );
+};
+
+export default EditStamps;

--- a/src/components/StampButtons.tsx
+++ b/src/components/StampButtons.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Stamp } from '../algorithm/stamp';
 import { Checkbox, Wrap, WrapItem, Box } from '@chakra-ui/react';
 
@@ -14,6 +14,10 @@ const StampButtons: React.FC<StampButtonsProps> = ({
   initialSelection,
 }) => {
   const [selected, setSelected] = useState<Map<string, Stamp>>(initialSelection);
+
+  useEffect(() => {
+    setSelected(new Map(initialSelection));
+  }, [initialSelection, stamps]);
 
   const isChecked = (stamp: Stamp): boolean => selected.has(stamp.id);
 

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -1,0 +1,9 @@
+export function setCookie(name: string, value: string, days = 365) {
+  const expires = new Date(Date.now() + days * 864e5).toUTCString();
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
+}
+
+export function getCookie(name: string): string | null {
+  const match = document.cookie.split('; ').find(row => row.startsWith(name + '='));
+  return match ? decodeURIComponent(match.split('=')[1]) : null;
+}


### PR DESCRIPTION
## Summary
- allow editing the numeric stamp list in a new `EditStamps` component
- persist stamp list and selection in a browser cookie
- reload the saved list on startup using new cookie helper

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68657df766f8833189a0f0ee8fc858e1